### PR TITLE
HeightSlice

### DIFF
--- a/feeder/lib/feeder.dart
+++ b/feeder/lib/feeder.dart
@@ -86,12 +86,14 @@ void run(DotEnv env) async {
 
   //parse utxo data into a map of height to count in 50k chunks
   Map<int, double> commulativeValueOfUtxos = {};
+  Map<int, double> heightsliceValueOfUtxos = {};
 
   for (int i = 0; i <= currentHeight; i += 50000) {
     valueList.where((element) => element.height <= i).forEach((element) {
       commulativeValueOfUtxos[i] = commulativeValueOfUtxos[i] == null
           ? element.value
           : commulativeValueOfUtxos[i]! + element.value;
+      heightsliceValueOfUtxos[i] = element.value;
     });
   }
 


### PR DESCRIPTION
This pull will not do anything but show what a "height slice" of utxos that have not moved since that Era would look like.  A histogram of this kind would be useful because all bars would sum to the total supply, i.e. it is a "normalized" chart.  As such, if we were to e.g. divide heightsliceValueOfUtxos by "total supply", we could maybe see some interesting properties.  Here, we could present it in two separate ways: one normalized to the current supply and thereby summing to 1, or one normalized to the supply *at the time*, which would be a funky little graph to think about and maybe play with.  Aaaaannnyyyway, first step is just looking at the raw elements.  You probably have looked at this already, moving toward the cumulative approach, but I think the raw elements in units of ppc are more valuable than their cumsum.